### PR TITLE
Db migrations

### DIFF
--- a/services/rust-monolith/migrations/00000000000000_diesel_initial_setup/down.sql
+++ b/services/rust-monolith/migrations/00000000000000_diesel_initial_setup/down.sql
@@ -1,0 +1,6 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+DROP FUNCTION IF EXISTS diesel_manage_updated_at(_tbl regclass);
+DROP FUNCTION IF EXISTS diesel_set_updated_at();

--- a/services/rust-monolith/migrations/00000000000000_diesel_initial_setup/up.sql
+++ b/services/rust-monolith/migrations/00000000000000_diesel_initial_setup/up.sql
@@ -1,0 +1,36 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+
+
+
+-- Sets up a trigger for the given table to automatically set a column called
+-- `updated_at` whenever the row is modified (unless `updated_at` was included
+-- in the modified columns)
+--
+-- # Example
+--
+-- ```sql
+-- CREATE TABLE users (id SERIAL PRIMARY KEY, updated_at TIMESTAMP NOT NULL DEFAULT NOW());
+--
+-- SELECT diesel_manage_updated_at('users');
+-- ```
+CREATE OR REPLACE FUNCTION diesel_manage_updated_at(_tbl regclass) RETURNS VOID AS $$
+BEGIN
+    EXECUTE format('CREATE TRIGGER set_updated_at BEFORE UPDATE ON %s
+                    FOR EACH ROW EXECUTE PROCEDURE diesel_set_updated_at()', _tbl);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION diesel_set_updated_at() RETURNS trigger AS $$
+BEGIN
+    IF (
+        NEW IS DISTINCT FROM OLD AND
+        NEW.updated_at IS NOT DISTINCT FROM OLD.updated_at
+    ) THEN
+        NEW.updated_at := current_timestamp;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/services/rust-monolith/migrations/2025-07-08-133527_create_users_and_files/down.sql
+++ b/services/rust-monolith/migrations/2025-07-08-133527_create_users_and_files/down.sql
@@ -1,0 +1,5 @@
+-- This file should undo anything in `up.sql`
+
+DROP TABLE IF EXISTS files;
+DROP TABLE IF EXISTS users;
+

--- a/services/rust-monolith/migrations/2025-07-08-133527_create_users_and_files/up.sql
+++ b/services/rust-monolith/migrations/2025-07-08-133527_create_users_and_files/up.sql
@@ -1,0 +1,23 @@
+-- Your SQL goes here
+
+-- Création de la table users
+CREATE TABLE users (
+    uuid TEXT PRIMARY KEY,
+    clerk_user_id TEXT NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    files INTEGER NOT NULL
+);
+
+-- Création de la table files
+CREATE TABLE files (
+    id SERIAL PRIMARY KEY,
+    uuid_of_users TEXT NOT NULL REFERENCES users(uuid) ON DELETE CASCADE,
+    date TEXT NOT NULL,
+    time TEXT NOT NULL,
+    iteration INTEGER NOT NULL
+);
+
+-- Optionnel : pour la jointure (index sur uuid_of_users)
+CREATE INDEX idx_files_uuid_of_users ON files(uuid_of_users);
+

--- a/services/rust-monolith/src/db/schema.rs
+++ b/services/rust-monolith/src/db/schema.rs
@@ -22,7 +22,4 @@ diesel::table! {
 
 diesel::joinable!(files -> users (uuid_of_users));
 
-diesel::allow_tables_to_appear_in_same_query!(
-    files,
-    users,
-);
+diesel::allow_tables_to_appear_in_same_query!(files, users,);

--- a/services/rust-monolith/src/db/schema.rs
+++ b/services/rust-monolith/src/db/schema.rs
@@ -1,24 +1,28 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
+    files (id) {
+        id -> Int4,
+        uuid_of_users -> Text,
+        date -> Text,
+        time -> Text,
+        iteration -> Int4,
+    }
+}
+
+diesel::table! {
     users (uuid) {
         uuid -> Text,
         clerk_user_id -> Text,
         created_at -> Timestamp,
         updated_at -> Timestamp,
-        files -> Integer
+        files -> Int4,
     }
 }
 
-diesel::table! {
-    files (id){
-        id -> Integer,
-        uuid_of_users -> Text,
-        date -> Text,
-        time -> Text,
-        iteration -> Integer,
-    }
-}
+diesel::joinable!(files -> users (uuid_of_users));
 
-diesel::joinable!(users -> files (files));
-diesel::allow_tables_to_appear_in_same_query!(users, files,);
+diesel::allow_tables_to_appear_in_same_query!(
+    files,
+    users,
+);


### PR DESCRIPTION
This pull request introduces database schema changes and corresponding Diesel migration updates for the `users` and `files` tables in the `rust-monolith` service. The key changes include the addition of new SQL migrations for table creation and cleanup, updates to Diesel's schema file, and the implementation of helper functions for managing the `updated_at` column.

### Database Schema and Migrations:

* Added an `up.sql` migration to create the `users` and `files` tables, including foreign key constraints, default timestamps, and an optional index for `uuid_of_users` in the `files` table.
* Added a corresponding `down.sql` migration to drop the `users` and `files` tables for rollback purposes.

### Diesel Schema Updates:

* Updated `schema.rs` to reflect the new `users` and `files` tables, including their respective columns and data types. Added a `joinable!` macro for the foreign key relationship and adjusted the `allow_tables_to_appear_in_same_query!` macro.

### Helper Functions for `updated_at` Management:

* Added an `up.sql` migration to define two PostgreSQL functions, `diesel_manage_updated_at` and `diesel_set_updated_at`, to automatically update the `updated_at` column on row modifications.
* Added a corresponding `down.sql` migration to drop these helper functions during rollbacks.